### PR TITLE
Node 20.11.1, CMake 3.28.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Docker setup-buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
 
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -42,7 +42,7 @@ jobs:
             type=edge
 
       - name: Docker build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILDCACHE_COMPRESS="true"
 ENV BUILDCACHE_DIRECT_MODE="true"
 ENV BUILDCACHE_ACCURACY="SLOPPY"
 ENV BUILDCACHE_LUA_PATH="/opt/buildcache/share/lua-examples"
-ENV PATH="/opt:/opt/node-v20.11.1-linux-x64/bin:/opt/cmake-3.26.3-linux-x86_64/bin:/opt/buildcache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PATH="/opt:/opt/node-v20.11.1-linux-x64/bin:/opt/cmake-3.28.3-linux-x86_64/bin:/opt/buildcache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # BASE SETUP
@@ -55,9 +55,9 @@ RUN wget https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz && \
     rm -rf node-v20.11.1-linux-x64.tar.xz
 
 # INSTALL CMAKE
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.tar.gz &&\
-    tar xf cmake-3.26.3-linux-x86_64.tar.gz -C /opt && \
-    rm -rf cmake-3.26.3-linux-x86_64.tar.gz
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz &&\
+    tar xf cmake-3.28.3-linux-x86_64.tar.gz -C /opt && \
+    rm -rf cmake-3.28.3-linux-x86_64.tar.gz
 
 # INSTALL PKG
 RUN wget https://github.com/motis-project/pkg/releases/download/v0.14/pkg-linux-amd64 -O /opt/pkg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILDCACHE_COMPRESS="true"
 ENV BUILDCACHE_DIRECT_MODE="true"
 ENV BUILDCACHE_ACCURACY="SLOPPY"
 ENV BUILDCACHE_LUA_PATH="/opt/buildcache/share/lua-examples"
-ENV PATH="/opt:/opt/node-v18.16.0-linux-x64/bin:/opt/cmake-3.26.3-linux-x86_64/bin:/opt/buildcache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PATH="/opt:/opt/node-v20.11.1-linux-x64/bin:/opt/cmake-3.26.3-linux-x86_64/bin:/opt/buildcache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # BASE SETUP
@@ -50,9 +50,9 @@ RUN wget https://github.com/motis-project/musl-toolchains/releases/download/v0.0
     rm -rf x86_64-multilib-linux-musl.tar.xz
 
 # INSTALL NODE JS
-RUN wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz && \
-    tar xf node-v18.16.0-linux-x64.tar.xz -C /opt && \
-    rm -rf node-v18.16.0-linux-x64.tar.xz
+RUN wget https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz && \
+    tar xf node-v20.11.1-linux-x64.tar.xz -C /opt && \
+    rm -rf node-v20.11.1-linux-x64.tar.xz
 
 # INSTALL CMAKE
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.tar.gz &&\


### PR DESCRIPTION
- Node.js: 18.16.0 -> 20.11.1 (current LTS)
- CMake: 3.26.3 -> 3.28.3 (current stable)